### PR TITLE
Fix broken plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,9 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# Mac files
+.DS_Store
+
+# Intellij
+.idea

--- a/scripts/components/renderTop/index.js
+++ b/scripts/components/renderTop/index.js
@@ -14,7 +14,7 @@ export const renderTop = () => {
     <nav class="banano--main-menu">
       <ul class="banano__menu--links">
       <li>
-      <a href="https://ban.family/fah" class="banano__top" title="Go to PPD-BAN estimation tool" target="_blank" style="padding-top:3px;">
+      <a href="https://turtlebyte.github.io/bananocalculator/" class="banano__top" title="Go to PPD-BAN estimation tool" target="_blank" style="padding-top:3px;">
         PPD-BAN estimation tool   
       </a>
       </li>

--- a/scripts/components/renderUser/fetchBananoMiner.js
+++ b/scripts/components/renderUser/fetchBananoMiner.js
@@ -24,9 +24,10 @@ export const fetchData = async (user) => {
   const bananoData = await Promise.all([
     fetch(`https://bananominer.com/user_name/${user}`),
     fetch(
-      `https://banano-cors-proxy.herokuapp.com/https://stats.foldingathome.org/api/donor/${user}`,
+      `https://banano-cors-proxy.herokuapp.com/https://api2.foldingathome.org/user/${user}`,
       {
         "Content-Type": "application/json",
+        "Origin": document.location.href
       }
     ),
   ]);
@@ -83,7 +84,8 @@ const renderComponent = (data) => {
     data[0].payments.forEach((el) => {
       totalAmount += el.amount;
     });
-  template += `<section class="banano__info"><h2>Score:</h2><p>${data[1].teams[0].credit}</p></section> `;
+  totalAmount = Math.round(totalAmount * 100) / 100;
+  template += `<section class="banano__info"><h2>Score:</h2><p>${data[1].teams[0].score}</p></section> `;
   template += `<section class="banano__info"><h2>${chrome.i18n.getMessage(
     "banEarned"
   )}</h2><p>${totalAmount}</p></section>`;


### PR DESCRIPTION
The main reason why it was broken:
- The proxy needs an origin, otherwise it won't work
- The previous F@H API is now deprecated, adjusted the URL to the new one plus adjusted a changed key

Also:
- The PPD/BAN estimation tool that was linked is no longer available. Linked the new tool by @turtlebyte instead.